### PR TITLE
Adds support for app clips extensions.

### DIFF
--- a/lib/configure_extensions/configure.rb
+++ b/lib/configure_extensions/configure.rb
@@ -17,7 +17,7 @@ module ConfigureExtensions
       extension_targets = extension_names.map do |ext|
         target = xc.targets.find { |t| t.name == ext }
         abort "Couldn't find a '#{ext}' target in '#{project_name}'" if target.nil?
-        abort "'#{ext}' doesn't seem to be an application extension target" unless target.product_type.include? 'app-extension'
+        abort "'#{ext}' doesn't seem to be an application extension target" unless target.product_type.include?('app-extension') || target.product_type.include?('application.on-demand-install-capable')
         target
       end
 

--- a/lib/configure_extensions/version.rb
+++ b/lib/configure_extensions/version.rb
@@ -1,3 +1,3 @@
 module ConfigureExtensions
-  VERSION = '1.0.1'
+  VERSION = '1.1.0'
 end


### PR DESCRIPTION
- iOS 14 introduces AppClips extensions which are not of `app-extension` type rather the type is `application.on-demand-install-capable`
- Added the support for AppClips to be added and removed as well. 
- Updated to v1.1.0

**I am not very good with releasing ruby gems, would be great if you can help me with releasing version 1.1.0 :)** 
