### PR TITLE
Search for both extensions and products subdir for app clips

### DIFF
--- a/lib/configure_extensions/configure.rb
+++ b/lib/configure_extensions/configure.rb
@@ -48,7 +48,7 @@ module ConfigureExtensions
       # Add or remove .appex copy jobs
 
       embed_extensions_phase = app_target.copy_files_build_phases.find do |copy_phase|
-        copy_phase.symbol_dst_subfolder_spec == :plug_ins
+        [:plug_ins, :products_directory].include?(copy_phase.symbol_dst_subfolder_spec)
       end
 
       abort "Couldn't find 'Embed App Extensions' phase" if embed_extensions_phase.nil?


### PR DESCRIPTION
App Clips reside in Products Directory (dstSubfolderSpec=16), not the extensions subfolder (dstSubfolderSpec=13).
There is also an "App Clips" destination in Xcode copy files phase, but it seems that it is a synonym for Product Directory (both set to dstSubfolderSpec=16)
